### PR TITLE
Gi dp-andre-ytelser lesetilgang til tsm.sykmeldinger

### DIFF
--- a/topics/tier-2/tsm-sykmeldinger.yml
+++ b/topics/tier-2/tsm-sykmeldinger.yml
@@ -35,6 +35,9 @@ spec:
     - team : tsm
       application: tsm-manuell-api
       access: read
+    - team: teamdagpenger
+      application: dp-andre-ytelser
+      access: read
   config:
     cleanupPolicy: compact
     minimumInSyncReplicas: 3


### PR DESCRIPTION
## Hva
Legger til `teamdagpenger:dp-andre-ytelser` som leser på `tsm.sykmeldinger`.

## Hvorfor
Team Dagpenger bygger [dp-andre-ytelser](https://github.com/navikt/dp-andre-ytelser) — en Rapids & Rivers-app som lytter på ytelseshendelser fra andre team og publiserer minimale `annen_ytelse_endret`-signaler på dagpenger-rapiden. Konsumenter (dp-behandling, dp-saksbehandling) bruker signalene til å reagere på endringer som kan påvirke dagpengeretten.

Sykmelding (med aktivitetsperioder) er én av flere kilder. Foreldrepenger er allerede på plass via tilsvarende mønster mot fp-abakus.

## Kontekst
Vi har en pågående samtale med TSM om eksakt format og diskriminator (`validation.status == OK`). Denne PR-en sender vi parallelt så ACL er klar når implementasjonen er det.

## Endring
- Tier-2 topic, kun `access: read`
- Ingen endringer på cleanup/retention/partitioner

cc @navikt/team-sykmelding